### PR TITLE
Allow coupons to be combined

### DIFF
--- a/integrations/class-woocommerce.php
+++ b/integrations/class-woocommerce.php
@@ -250,7 +250,7 @@ class AffiliateWP_Store_Credit_WooCommerce extends AffiliateWP_Store_Credit_Base
 		$user_id      = ( $user_id ) ? $user_id : get_current_user_id();
 		$user_info    = get_userdata( $user_id );
 		$affiliate_id = is_int( $affiliate_id ) ? $affiliate_id : affwp_get_affiliate_id( $user_id );
-		$date         = current_time( 'Ymds' );
+		$date         = current_time( 'YmdHi' );
 		$coupon_code  = 'AFFILIATE-CREDIT-' . $date . '_' . $user_id;
 		$expires      = $this->coupon_expires();
 
@@ -264,7 +264,7 @@ class AffiliateWP_Store_Credit_WooCommerce extends AffiliateWP_Store_Credit_Base
 		$coupon_data = apply_filters( 'affwp_store_credit_woocommerce_coupon_data', array(
 			'discount_type'    => 'fixed_cart',
 			'coupon_amount'    => $amount,
-			'individual_use'   => 'yes',
+			'individual_use'   => 'no',
 			'usage_limit'      => '1',
 			'expiry_date'      => $expires,
 			'apply_before_tax' => 'yes',


### PR DESCRIPTION
Previously the date format was set to `Ymds` which allowed generated coupons with a unique hash to be created multiple times. A user could click the apply credit button and generate multiple coupons, applying them and totaling a greater value than the store credit they had to use. 

This commit changes the date format to `YmdHi` switching seconds for hour and minutes. Now if you click the apply coupon multiple times, the first coupon will generate and any subsequent coupons will fail to generate since a coupon with the same unique id already exists. 

An edge case still exists where the person could do this right when the minute changes. At most it would allow them 2 generated coupons while the server was responding. This would require the customer to know the exact server time to start clicking and span the 59-00 second/minute change. In testing I was unable to successfully accomplish this. In looking at this more objectively, this could also apply if you reduced to hours, or days. There always exists a couple second point of time where the server is loading and a minute to minute, hour to hour, or day to day change is happening. It's a race condition that can't be beat, but has a low probability of being exploited successfully. 

Fixes #67 #74