### PR TITLE
Issue/108 - Adds missing coupon metadata to WooCommerce coupon.

### DIFF
--- a/integrations/class-woocommerce.php
+++ b/integrations/class-woocommerce.php
@@ -269,6 +269,7 @@ class AffiliateWP_Store_Credit_WooCommerce extends AffiliateWP_Store_Credit_Base
 			'coupon_amount'    => $amount,
 			'individual_use'   => 'no',
 			'usage_limit'      => '1',
+//			'usage_count'      => '0',
 			'expiry_date'      => $expires,
 			'apply_before_tax' => 'yes',
 			'free_shipping'    => 'no',

--- a/integrations/class-woocommerce.php
+++ b/integrations/class-woocommerce.php
@@ -264,6 +264,14 @@ class AffiliateWP_Store_Credit_WooCommerce extends AffiliateWP_Store_Credit_Base
 			affwp_get_affiliate_payment_email( $affiliate_id )
 		);
 
+		/**
+		 * Filters store credit data for coupons.
+		 *
+		 * @since 2.0
+		 * @since 2.5 Adds usage count to coupon data.
+		 *
+		 * @param array $coupon_data The coupon metadata.
+		 */
 		$coupon_data = apply_filters( 'affwp_store_credit_woocommerce_coupon_data', array(
 			'discount_type'    => 'fixed_cart',
 			'coupon_amount'    => $amount,

--- a/integrations/class-woocommerce.php
+++ b/integrations/class-woocommerce.php
@@ -269,7 +269,7 @@ class AffiliateWP_Store_Credit_WooCommerce extends AffiliateWP_Store_Credit_Base
 			'coupon_amount'    => $amount,
 			'individual_use'   => 'no',
 			'usage_limit'      => '1',
-//			'usage_count'      => '0',
+			'usage_count'      => '0',
 			'expiry_date'      => $expires,
 			'apply_before_tax' => 'yes',
 			'free_shipping'    => 'no',


### PR DESCRIPTION
This fixes an issue that caused WooCommerce coupons to incorrectly assume that the generated coupon has already been used.

Issue #108 