### PR TITLE
Version 2.3.4 Release

### DIFF
--- a/affiliatewp-store-credit.php
+++ b/affiliatewp-store-credit.php
@@ -5,8 +5,8 @@
  * Description: Pay AffiliateWP referrals as store credit
  * Author: Sandhills Development, LLC
  * Author URI: https://sandhillsdev.com
- * Contributors: ryanduff, ramiabraham, mordauk, sumobi, patrickgarman, section214, tubiz
- * Version: 2.3.3
+ * Contributors: ryanduff, ramiabraham, mordauk, sumobi, patrickgarman, section214, tubiz, paninapress
+ * Version: 2.3.4
  * Text Domain: affiliatewp-store-credit
  */
 
@@ -71,7 +71,7 @@ final class AffiliateWP_Store_Credit {
 			self::$instance = new AffiliateWP_Store_Credit;
 
 			self::$plugin_dir = plugin_dir_path( __FILE__ );
-			self::$version = '2.3.3';
+			self::$version = '2.3.4';
 
 			self::$instance->setup_constants();
 			self::$instance->load_textdomain();

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -21,6 +21,10 @@ class AffiliateWP_Store_Credit_Admin {
 			add_filter( 'affwp_affiliate_table_store_credit', array( $this, 'column_store_credit_value' ), 10, 2 );
 			add_filter( 'affwp_affiliate_table_payout_method', array( $this, 'column_payment_method_value' ), 10, 2 );
 
+			// Add a "Payout Method" column to the referrals admin screen.
+			add_filter( 'affwp_referral_table_columns', array( $this, 'referrals_column_store_credit' ), 10, 3 );
+			add_filter( 'affwp_referral_table_payout_method', array( $this, 'referrals_column_payment_method_value' ), 10, 2 );
+
 			// Add the Store Credit Balance to the edit affiliate screen.
 			add_action( 'affwp_edit_affiliate_end', array( $this, 'edit_affiliate_store_credit_settings' ), 10, 1 );
 
@@ -83,6 +87,43 @@ class AffiliateWP_Store_Credit_Admin {
 	public function column_payment_method_value( $value, $affiliate ) {
 
 		$value = $this->get_payout_method( $affiliate->affiliate_id );
+
+		return $value;
+	}
+
+	/**
+	 * Adds a "Payment Method" column to the referrals screen.
+	 * 
+	 * @since 2.3.4
+	 *
+	 * @param array  $prepared_columns Prepared columns.
+	 * @param array  $columns  The columns for this list table.
+	 * @param object $instance List table instance.
+	 * @return array Prepared columns.
+	 */
+	public function referrals_column_store_credit( $prepared_columns, $columns, $instance ) {
+
+		$offset = 8;
+
+		$prepared_columns = array_slice( $prepared_columns, 0, $offset, true ) +
+		                    array( 'payout_method' => __( 'Payout Method', 'affiliatewp-store-credit' ) ) +
+		                    array_slice( $prepared_columns, $offset, null, true );
+
+		return $prepared_columns;
+	}
+
+	/**
+	 * Shows the payment method for each referral.
+	 *
+	 * @since 2.3.4
+	 *
+	 * @param string $value     The column data.
+	 * @param object $affiliate The current affiliate object.
+	 * @return string The affiliate's payment method.
+	 */
+	public function referrals_column_payment_method_value( $value, $referral ) {
+
+		$value = $this->get_payout_method( $referral->affiliate_id );
 
 		return $value;
 	}

--- a/integrations/class-woocommerce.php
+++ b/integrations/class-woocommerce.php
@@ -323,7 +323,11 @@ class AffiliateWP_Store_Credit_WooCommerce extends AffiliateWP_Store_Credit_Base
 		$user_id = $order->get_user_id();
 
 		// Grab an array of coupons used
-		$coupons = $order->get_used_coupons();
+		if ( version_compare( WC()->version, '3.7.0', '>=' ) ) {
+			$coupons = $order->get_coupon_codes();
+		} else {
+			$coupons = $order->get_used_coupons();
+		}
 
 		// If the order has coupons
 		if( $coupon_code = $this->check_for_coupon( $coupons ) ) {
@@ -467,7 +471,11 @@ class AffiliateWP_Store_Credit_WooCommerce extends AffiliateWP_Store_Credit_Base
 		$user_id = $last_order->get_user_id();
 
 		// Grab an array of coupons used.
-		$coupons = $last_order->get_used_coupons();
+		if ( version_compare( WC()->version, '3.7.0', '>=' ) ) {
+			$coupons = $last_order->get_coupon_codes();
+		} else {
+			$coupons = $last_order->get_used_coupons();
+		}
 
 		// If the order has coupons.
 		if ( $coupon_code = $this->check_for_coupon( $coupons ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Author: ramiabraham
 Contributors: ryanduff, ramiabraham, mordauk, sumobi, patrickgarman, section214, drewapicture, tubiz, alexstandiford
 Tags: affiliatewp, affiliates, store credit, woo, woocommerce, easy digital downloads, edd
 License: GPLv2 or later
-Tested up to: 5.5
+Tested up to: 5.7
 Requires PHP: 5.3
 Stable tag: 2.3.3
 Requires at least: 3.5

--- a/readme.txt
+++ b/readme.txt
@@ -8,7 +8,7 @@ Tags: affiliatewp, affiliates, store credit, woo, woocommerce, easy digital down
 License: GPLv2 or later
 Tested up to: 5.7
 Requires PHP: 5.3
-Stable tag: 2.3.3
+Stable tag: 2.3.4
 Requires at least: 3.5
 
 == Description ==

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,11 @@ A: Yes! There is an option that lets site admins enable that profile setting for
 
 == Changelog ==
 
+= Version 2.3.4, March 22, 2021 =
+* Improved: Add indicator to see what referrals should be paid in Store Credit
+* Improved: Tested up to WordPress 5.7
+* Fixed: Adjust how used coupon codes are retrieved in WooCommerce 3.7+
+
 = Version 2.3.3, February 24, 2020 =
 * Fix [WooCommerce integration]: Store credit cannot be used
 


### PR DESCRIPTION
Issues: https://github.com/AffiliateWP/affiliatewp-store-credit/milestone/11?closed=1

| Type | Ticket | Description |
| :----: | ------ | :----------- |
| Improved | #101  | Add indicator to see what referrals should be paid in Store Credit |
| Improved | #125  | Tested up to WordPress 5.7 |
| Fixed | #112  | Adjust how used coupon codes are retrieved in WooCommerce 3.7+ |